### PR TITLE
Add comment to order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea/

--- a/lib/magento_api_wrapper.rb
+++ b/lib/magento_api_wrapper.rb
@@ -14,6 +14,7 @@ require 'magento_api_wrapper/requests/create_shipment'
 require 'magento_api_wrapper/requests/shipment_list'
 require 'magento_api_wrapper/requests/shipment_info'
 require 'magento_api_wrapper/requests/add_tracking_to_shipment'
+require 'magento_api_wrapper/requests/add_comment_to_order'
 
 require 'magento_api_wrapper/response'
 require 'magento_api_wrapper/responses'

--- a/lib/magento_api_wrapper/api/sales.rb
+++ b/lib/magento_api_wrapper/api/sales.rb
@@ -171,5 +171,28 @@ module MagentoApiWrapper
       end
     end
 
+    def add_comment_to_order(params = {})
+      begin
+        order_increment_id = params[:order_increment_id]
+        comment = params[:comment]
+        status = params[:status]
+
+        if order_increment_id
+          params.merge!(session_params)
+          params.merge!(order_increment_id: order_increment_id)
+          params.merge!(comment: comment)
+          params.merge!(status: status)
+          document = MagentoApiWrapper::Requests::AddCommentToOrder.new(params)
+          request = MagentoApiWrapper::Request.new(magento_url: params[:magento_url], call_name: :sales_order_add_comment)
+          request.body = document.body
+          MagentoApiWrapper::AddCommentToOrder.new(request.connect!)
+          true
+        end
+
+      rescue => e
+        raise e
+      end
+    end
+
   end
 end

--- a/lib/magento_api_wrapper/requests/add_comment_to_order.rb
+++ b/lib/magento_api_wrapper/requests/add_comment_to_order.rb
@@ -1,0 +1,40 @@
+module MagentoApiWrapper::Requests
+  class AddCommentToOrder
+
+    attr_accessor :data
+
+    def initialize(data = {})
+      @data = data
+    end
+
+    def body
+      order_comment_request_hash
+    end
+
+    def order_comment_request_hash
+      {
+          session_id: self.session_id,
+          order_increment_id: self.order_increment_id,
+          status: self.status,
+          comment: self.comment
+      }
+    end
+
+    def session_id
+      data[:session_id]
+    end
+
+    def order_increment_id
+      data[:order_increment_id]
+    end
+
+    def status
+      data[:status]
+    end
+
+    def comment
+      data[:comment]
+    end
+
+  end
+end

--- a/lib/magento_api_wrapper/responses.rb
+++ b/lib/magento_api_wrapper/responses.rb
@@ -205,4 +205,18 @@ module MagentoApiWrapper
       #true or false
     end
   end
+
+  class AddCommentToOrder < MagentoApiWrapper::Response
+    def initialize(response)
+      super
+    end
+
+    def result
+      @document[:sales_order_add_comment_response][:result]
+    end
+
+    def success?
+      #true or false
+    end
+  end
 end


### PR DESCRIPTION
Added function to add a comment to an order.

example use: 
require 'magento_api_wrapper'
api = MagentoApiWrapper::Sales.new(magento_url: 'https://your.domain.com', magento_username: 'api_username', magento_api_key: 'api_key')
api.add_comment_to_order(order_increment_id: '200001234', status: 'complete', comment: 'some message')