### PR TITLE
Check if params[:session_id] is nil before accessing it

### DIFF
--- a/lib/magento_api_wrapper/api/sales.rb
+++ b/lib/magento_api_wrapper/api/sales.rb
@@ -80,7 +80,7 @@ module MagentoApiWrapper
     #order.payment_info (returns order payment information only)
     def order_info(params = {})
       params.merge!(common_params)
-      params.merge!(session_params) unless params[:session_id].present?
+      params.merge!(session_params) unless ! params[:session_id].nil? and params[:session_id].present?
       document = MagentoApiWrapper::Requests::SalesOrderInfo.new(params)
       request = MagentoApiWrapper::Request.new(magento_url: params[:magento_url], call_name: :sales_order_info)
       request.body = document.body


### PR DESCRIPTION
When calling the order_info function in the sales module I got an error message: undefined method present? for Nil object. 
So I added a check if params[:session_id] is nil before params[:session_id].present? is called.